### PR TITLE
deps: update aontu for both languages

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -2,12 +2,12 @@ module github.com/voxgig/model/go
 
 go 1.24.7
 
-require github.com/rjrodger/aontu/go v0.1.2
+require github.com/rjrodger/aontu/go v0.1.3
 
 require (
 	github.com/jsonicjs/directive/go v0.1.4 // indirect
 	github.com/jsonicjs/expr/go v0.1.3 // indirect
 	github.com/jsonicjs/jsonic/go v0.1.22 // indirect
-	github.com/jsonicjs/multisource/go v0.1.4 // indirect
+	github.com/jsonicjs/multisource/go v0.1.6 // indirect
 	github.com/jsonicjs/path/go v0.1.2 // indirect
 )

--- a/go/go.sum
+++ b/go/go.sum
@@ -4,9 +4,9 @@ github.com/jsonicjs/expr/go v0.1.3 h1:D7x+5AIM/CLX6A6VUiHBzfvRxufuGzXYB6gmPb1lv+
 github.com/jsonicjs/expr/go v0.1.3/go.mod h1:6kmd1o4p4/FL4DVuCxwYAqX5YRYjF20hbIrHQM81Qoc=
 github.com/jsonicjs/jsonic/go v0.1.22 h1:sam238fTyjDq0nby9TYS+aCCHprLl91ArQPWLCg2O0Y=
 github.com/jsonicjs/jsonic/go v0.1.22/go.mod h1:ObNKlCG7esWoi4AHCpdgkILvPINV8bpvkbCd4llGGUg=
-github.com/jsonicjs/multisource/go v0.1.4 h1:vTfr1pHNuKV6XBSErZpi2fA4SjVvX5DfoQs7nEoQzko=
-github.com/jsonicjs/multisource/go v0.1.4/go.mod h1:XzgM6nuW2MOAsVySsGtpp7fWSx9PTCXd4eIRSCAA/6o=
+github.com/jsonicjs/multisource/go v0.1.6 h1:FGOySI7hmFjsmcI/mbnBF04DFFOb5FqR2fOydOCoSuA=
+github.com/jsonicjs/multisource/go v0.1.6/go.mod h1:XzgM6nuW2MOAsVySsGtpp7fWSx9PTCXd4eIRSCAA/6o=
 github.com/jsonicjs/path/go v0.1.2 h1:Pk7PZIiRq64iodssEVtaJw+4jHiJe84aFtmKDUasXAo=
 github.com/jsonicjs/path/go v0.1.2/go.mod h1:ffXuSMg950pdfU3wapeK6QnyvZrV5yHFSj4ifwmsgmU=
-github.com/rjrodger/aontu/go v0.1.2 h1:vTStp1UIbTxGovcPH+29FwZ3eNwzaJUMV8PXEtz6Lmk=
-github.com/rjrodger/aontu/go v0.1.2/go.mod h1:Ejv19nAWPMFlzqc1rdkvIEjh1dihKf8S2uiGigyQyYE=
+github.com/rjrodger/aontu/go v0.1.3 h1:jEMxKpN8C7ijCaFCmXCL8r3YI7wtvYkeyVGYSbO4pCw=
+github.com/rjrodger/aontu/go v0.1.3/go.mod h1:wvCO27yvs2Rdr8bLD/hEn4e0+Qxz6rQImkhC3y8lgzc=

--- a/ts/package.json
+++ b/ts/package.json
@@ -43,7 +43,7 @@
     "LICENSE"
   ],
   "dependencies": {
-    "aontu": "0.45.1",
+    "aontu": "0.46.0",
     "chokidar": "5.0.0",
     "shape": "10.1.0",
     "memfs": "4.57.6"


### PR DESCRIPTION
- ts: aontu 0.45.1 -> 0.46.0 (all other TS deps already latest). Build clean, 22/22 tests pass, 0 vulnerabilities; compiled dist unchanged (runtime-only dependency).
- go: aontu/go v0.1.2 -> v0.1.3 and multisource/go v0.1.4 -> v0.1.6 (go get -u ./...). gofmt/vet clean, all tests pass.

make test is green for both languages.

https://claude.ai/code/session_01HxXpZNrKj3qonocwAtEP8r