### PR TITLE
ci: add updated dual-language workflow under ci/ for manual apply

### DIFF
--- a/ci/.github/workflows/build.yml
+++ b/ci/.github/workflows/build.yml
@@ -1,0 +1,70 @@
+# Builds and tests both implementations: TypeScript (ts/) and Go (go/).
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  ts:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        node-version: [24.x]
+
+    runs-on: ${{ matrix.os }}
+
+    defaults:
+      run:
+        working-directory: ts
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm i
+    - run: npm run build --if-present
+    - run: npm test
+
+    - name: test-cov
+      if: matrix.os == 'ubuntu-latest'
+      run: npm run test-cov
+
+    - name: coveralls
+      if: matrix.os == 'ubuntu-latest'
+      uses: coverallsapp/github-action@main
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        path-to-lcov: ./ts/coverage/lcov.info
+
+  go:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    defaults:
+      run:
+        working-directory: go
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.24'
+    - run: go build ./...
+    - run: go vet ./...
+    - name: gofmt
+      if: matrix.os == 'ubuntu-latest'
+      run: test -z "$(gofmt -l .)"
+    - run: go test ./...

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,34 @@
+# CI workflow (apply manually)
+
+This folder mirrors the repository's `.github/` directory with the workflow
+updated for the dual-language (`ts/` + `go/`) layout. It lives here because the
+workflow file could not be pushed automatically — the session's token lacked
+the GitHub `workflow` scope.
+
+## Apply
+
+Copy it over the repository root, then commit:
+
+```bash
+cp -r ci/.github/. .github/
+git add .github/workflows/build.yml
+git commit -m "ci: build and test ts/ and go/"
+```
+
+(Equivalently, copy `ci/.github/workflows/build.yml` to
+`.github/workflows/build.yml`.)
+
+## What changed
+
+The previous workflow ran `npm` from the repository root, which no longer
+works now that the TypeScript package lives in `ts/`. The updated `build.yml`
+has two jobs:
+
+- **ts** — `npm i` / `npm run build` / `npm test` in `ts/`, across
+  ubuntu/windows/macOS (Node 24), plus `test-cov` + Coveralls on ubuntu
+  (`path-to-lcov: ./ts/coverage/lcov.info`).
+- **go** — `go build` / `go vet` / `go test` in `go/`, across the same OSes
+  (Go 1.24), with a `gofmt` check on ubuntu (formatting is OS-independent, so
+  one check suffices).
+
+Once applied, this `ci/` folder can be deleted.


### PR DESCRIPTION
The TypeScript package now lives in ts/, so the committed .github/workflows/build.yml (which runs npm from the root) is stale. This ci/ folder mirrors an updated .github with a two-job workflow (ts + go); copy ci/.github over the repo root to apply. Provided this way because the session token lacks the GitHub workflow scope.

https://claude.ai/code/session_01HxXpZNrKj3qonocwAtEP8r